### PR TITLE
Publication du UMD

### DIFF
--- a/docs/Introduction.md
+++ b/docs/Introduction.md
@@ -16,7 +16,11 @@ yarn add -D socomodule
 
 ## Install socomodule (UMD)
 
-**Download the UMD module**:
+Download the UMD module:
 
-Check out the [GitHub releases](https://github.com/socialement-competents/socomodule/releases).
+Check out the latest [GitHub releases](https://github.com/socialement-competents/socomodule/releases).
 Download and extract the latest socomodule-umd.zip.
+
+Or just use the unpkg CDN, for exemple:
+https://unpkg.com/socomodule@1.1.5/umd/socomodule.min.js
+https://unpkg.com/socomodule@1.1.5/umd/socomodule.min.css

--- a/docs/UseCase2.md
+++ b/docs/UseCase2.md
@@ -1,5 +1,7 @@
 ## Use in any web application
 
+[Exemple](https://codepen.io/tsauvajon/pen/JvmrEo) in CodePen
+
 ```html
 <head>
   <script src="socomodule.min.js" charset="utf-8"></script>

--- a/package/publish-package.json
+++ b/package/publish-package.json
@@ -18,7 +18,9 @@
     "socomodule.min.css",
     "socomodule.min.js.map",
     "socomodule.min.css.map",
-    "assets/chat.svg",
-    "assets/cross.svg"
+    "umd/socomodule.min.js",
+    "umd/socomodule.min.css",
+    "umd/socomodule.min.js.map",
+    "umd/socomodule.min.css.map"
   ]
 }

--- a/package/publish.sh
+++ b/package/publish.sh
@@ -1,6 +1,7 @@
 #!/bin/sh
 
 mkdir tmp
+mkdir tmp/umd
 
 # Append all the documentation into 1 file
 cat docs/Introduction.md >> tmp/Readme.md
@@ -9,6 +10,7 @@ cat docs/UseCase2.md >> tmp/Readme.md
 
 # Copy the required assets
 cp dist/cjs/* tmp/
+cp dist/umd/* tmp/umd/
 cp package/publish-package.json tmp/package.json
 
 # Update the version defined in package.json to the tag version

--- a/release.sh
+++ b/release.sh
@@ -12,6 +12,22 @@ $GR release \
   --tag $CIRCLE_TAG \
   --name $CIRCLE_TAG
 
+FILENAME=socomodule.min
+
+$GR upload \
+  --user $CIRCLE_PROJECT_USERNAME \
+  --repo $CIRCLE_PROJECT_REPONAME \
+  --tag $CIRCLE_TAG \
+  --name $FILENAME.js \
+  --file umd/$FILENAME.js
+
+$GR upload \
+  --user $CIRCLE_PROJECT_USERNAME \
+  --repo $CIRCLE_PROJECT_REPONAME \
+  --tag $CIRCLE_TAG \
+  --name $FILENAME.css \
+  --file umd/$FILENAME.css
+
 # Add all files and folders, recursively, to a tag-named .zip
 cd umd
 UMD_FILENAME="$CIRCLE_PROJECT_REPONAME-umd-$CIRCLE_TAG.zip"


### PR DESCRIPTION
- publication directe du `.min.js` et du `.min.css` (non zippés) sur GitHub Releases
- publication du dossier umd sur npm pour pouvoir utiliser unpck, par exemple https://unpkg.com/socomodule@1.1.5/umd/socomodule.min.js